### PR TITLE
docs: fix typo Developement → Development in CITATION

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,1 @@
-"EIC Tutorial: Geometry Developement Using DD4hep," Computing & Software Working Group, Simulation, Production, and QA Working Group, 2022.
+"EIC Tutorial: Geometry Development Using DD4hep," Computing & Software Working Group, Simulation, Production, and QA Working Group, 2022.


### PR DESCRIPTION
Simple typo fix:  → .